### PR TITLE
Fix spelling errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Geo::Gpx - Create and parse GPX files
 
     A _$regex_ may be provided to limit the merge to a subset of waypoints from _$gpx_.
 
-    Returns the number of points succesfully merged (i.e. the difference in `$gps->waypoints_count` before and after the merge).
+    Returns the number of points successfully merged (i.e. the difference in `$gps->waypoints_count` before and after the merge).
 
 - waypoint\_closest\_to( $point of $tcx\_trackpoint )
 

--- a/lib/Geo/Gpx.pm
+++ b/lib/Geo/Gpx.pm
@@ -537,7 +537,7 @@ Merge waypoints with those contained in the L<Geo::Gpx> instance provide as argu
 
 A I<$regex> may be provided to limit the merge to a subset of waypoints from I<$gpx>.
 
-Returns the number of points succesfully merged (i.e. the difference in C<< $gps->waypoints_count >> before and after the merge).
+Returns the number of points successfully merged (i.e. the difference in C<< $gps->waypoints_count >> before and after the merge).
 
 =back
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * succesfully -> successfully