### PR TITLE
Fix spelling errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Geo::Gpx - Create and parse GPX files
 
     `unsafe_chars` can be provided to specify which characters to consider unsafe in generating the XML mark-up. This field is then passed through to [HTML::Entities](https://metacpan.org/pod/HTML%3A%3AEntities) function calls whose documentation describes that this field is "specified using the regular expression character class syntax (what you find within brackets in regular expressions)".
 
-    As of version _1.11_ of `Geo::Gpx`, the default set of characters are the `'<'`, `'&'`, `'>'`, `'"'` characters. To revert to the pre-version _1.11_ default, which is equivalent to that in <`HTML::Entities`, explicitely specify `unsafe_chars => undef`. This will encode as the latter module describes the "control chars, high-bit chars, and the `'<'`, `'&'`, `'>'`, `"'"`, `'"'` characters".
+    As of version _1.11_ of `Geo::Gpx`, the default set of characters are the `'<'`, `'&'`, `'>'`, `'"'` characters. To revert to the pre-version _1.11_ default, which is equivalent to that in <`HTML::Entities`, explicitly specify `unsafe_chars => undef`. This will encode as the latter module describes the "control chars, high-bit chars, and the `'<'`, `'&'`, `'>'`, `"'"`, `'"'` characters".
 
 - TO\_JSON
 

--- a/lib/Geo/Gpx.pm
+++ b/lib/Geo/Gpx.pm
@@ -1180,7 +1180,7 @@ If C<version> is omitted, it defaults to the value of the C<version> attribute. 
 
 C<unsafe_chars> can be provided to specify which characters to consider unsafe in generating the XML mark-up. This field is then passed through to L<HTML::Entities> function calls whose documentation describes that this field is "specified using the regular expression character class syntax (what you find within brackets in regular expressions)".
 
-As of version I<1.11> of C<Geo::Gpx>, the default set of characters are the C<< '<' >>, C<'&'>, C<< '>' >>, C<'"'> characters. To revert to the pre-version I<1.11> default, which is equivalent to that in <C<HTML::Entities>, explicitely specify C<< unsafe_chars => undef >>. This will encode as the latter module describes the "control chars, high-bit chars, and the C<< '<' >>, C<'&'>, C<< '>' >>, C<< "'" >>, C<'"'> characters".
+As of version I<1.11> of C<Geo::Gpx>, the default set of characters are the C<< '<' >>, C<'&'>, C<< '>' >>, C<'"'> characters. To revert to the pre-version I<1.11> default, which is equivalent to that in <C<HTML::Entities>, explicitly specify C<< unsafe_chars => undef >>. This will encode as the latter module describes the "control chars, high-bit chars, and the C<< '<' >>, C<'&'>, C<< '>' >>, C<< "'" >>, C<'"'> characters".
 
 =cut
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * explicitely -> explicitly